### PR TITLE
Additional functionality and fixes.

### DIFF
--- a/EventWay.Core/Aggregate.cs
+++ b/EventWay.Core/Aggregate.cs
@@ -21,7 +21,6 @@ namespace EventWay.Core
             Id = id;
 
             _uncommittedEvents = new List<object>();
-
             _commandHandlers = new Dictionary<Type, Func<object, object>>();
             _eventHandlers = new Dictionary<Type, Action<object>>();
         }
@@ -100,6 +99,18 @@ namespace EventWay.Core
             int numSnapshots = (Version - 1) / SnapshotSize;
             if ((Version - numSnapshots) % SnapshotSize == 0)
                 SaveSnapshot();
+        }
+
+        protected void Publish(object[] events)
+        {
+            foreach (var @event in events)
+                Publish(@event);
+        }
+
+        protected void Publish(IEnumerable<object> events)
+        {
+            foreach (var @event in events)
+                Publish(@event);
         }
 
         private void SaveSnapshot()

--- a/EventWay.Core/Aggregate.cs
+++ b/EventWay.Core/Aggregate.cs
@@ -131,13 +131,13 @@ namespace EventWay.Core
         {
             var commandType = AssertCommandHandler(command);
 
-            _commandHandlers[commandType](command);
+            if (commandType != null)
+                _commandHandlers[commandType](command);
         }
 
         public T Ask<T>(IDomainCommand command)
         {
             var commandType = AssertCommandHandler(command);
-
             return (T)_commandHandlers[commandType](command);
         }
 
@@ -146,7 +146,10 @@ namespace EventWay.Core
             // Get command type and throw error if command has no handler in aggregate
             var commandType = command.GetType();
             if (!_commandHandlers.ContainsKey(commandType))
-                throw new MissingMethodException($"Command of type {command.GetType()}. not handled");
+            {
+                UnhandledCommand(command);
+                return null;
+            }
 
             return commandType;
         }
@@ -156,6 +159,11 @@ namespace EventWay.Core
         /// </summary>
         /// <param name="event"></param>
         protected virtual void UnhandledEvent(object @event) {}
+
+        protected virtual void UnhandledCommand(object command)
+        {
+            throw new MissingMethodException($"Command of type {command.GetType()}. not handled");
+        }
 
         protected virtual object GetState()
         {

--- a/EventWay.Core/AggregateRepository.cs
+++ b/EventWay.Core/AggregateRepository.cs
@@ -36,6 +36,8 @@ namespace EventWay.Core
                 events.Select(x => x.EventPayload).ToArray()
             );
 
+            aggregate.Version = lastEventIndex ?? 0;
+
             return aggregate;
         }
 

--- a/EventWay.Infrastructure.MsSql/SqlServerEventRepository.cs
+++ b/EventWay.Infrastructure.MsSql/SqlServerEventRepository.cs
@@ -60,7 +60,7 @@ namespace EventWay.Infrastructure.MsSql
         {
             using (var conn = new SqlConnection(_connectionString))
             {
-                const string sql = "SELECT * FROM Events WHERE AggregateId=@aggregateId AND Ordering > @from";
+                const string sql = "SELECT * FROM Events WHERE AggregateId=@aggregateId AND Version > @from";
 
                 var listOfEventData = conn.Query<Event>(sql, new { aggregateId, from }, commandTimeout: CommandTimeout);
 

--- a/EventWay.Infrastructure/DefaultAggregateFactory.cs
+++ b/EventWay.Infrastructure/DefaultAggregateFactory.cs
@@ -27,7 +27,7 @@ namespace EventWay.Infrastructure
                      null);
 
             aggregate.Id = aggregateId;
-
+            
             if (events != null)
                 foreach (var @event in events)
                     aggregate.Apply(@event);


### PR DESCRIPTION
Added: UnhandledCommand method in Aggregate to support "external" command handlers.
Fix: Set Aggregate.Version to "latest version" from DB.
Fix: When selecting events "after" a snapshot we now filter on event Version instead of Ordering.